### PR TITLE
Set up Melissa Gem to work with SmartWeb Property API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 vendor
+.secrets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,13 +4,14 @@ PATH
     melissa (0.0.4)
       activesupport
       ffi
-      minitest
+      nokogiri
+      rest-client
       thread_safe
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -18,11 +19,17 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    ffi (1.9.8)
-    ffi (1.9.8-java)
+    coderay (1.1.0)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    ffi (1.9.10)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
-    json (1.8.2)
-    json (1.8.2-java)
+    json (1.8.3)
+    method_source (0.8.2)
+    mime-types (2.6.2)
+    mini_portile (0.6.2)
     minitest (5.4.0)
     minitest-reporters (1.0.8)
       ansi
@@ -30,13 +37,27 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     minitest-stub_any_instance (1.0.0)
+    netrc (0.10.3)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    pry (0.10.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     ruby-progressbar (1.7.1)
     shoulda-context (1.2.1)
+    slop (3.6.0)
     thread_safe (0.3.5)
-    thread_safe (0.3.5-java)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   java
@@ -47,6 +68,7 @@ DEPENDENCIES
   minitest
   minitest-reporters
   minitest-stub_any_instance
+  pry
   rake
   shoulda-context
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,215 @@ Or install it yourself as:
 
 ## Usage
 
+### Smart Web APIs
+
+#### Property
+There is a client included for the property API on Melissa. This requires very little.
+You will need two environment variables: `MELISSA_DATA_WEB_SMART_ID`, and `MELISSA_DATA_PROPERTY_API_URL`
+Once you have these, you may use the following client. To instantiate a client:
+
+```ruby
+irb> client = Melissa::WebSmart::Client.new
+irb> client.property(some_fips_code, some_apn) 
+# => property data
+```
+
+Data comes in the following form:
+
+```json
+{
+    "record_id": null,
+    "result": {
+        "code": "YS01,YS03,YC01,GS05",
+        "description": "FIPS/APN Match Found. Basic information returned."
+    },
+    "parcel": {
+        "fips_code": "12071",
+        "fips_sub_code": null,
+        "unformatted_apn": null,
+        "apn_sequence_no": null,
+        "formatted_apn": "24-43-24-03-00022.0040",
+        "original_apn": null,
+        "census_tract": null,
+        "zoning": null,
+        "range": null,
+        "township": null,
+        "section": null,
+        "quarter_section": null,
+        "homestead_exempt": null,
+        "absentee_owner_code": null,
+        "land_use_code": null,
+        "county_land_use1": null,
+        "county_land_use2": null,
+        "property_indicator_code": null,
+        "municipality_name": null,
+        "view_code": null,
+        "location_influence_code": null,
+        "number_of_buildings": null
+    },
+    "property_address": {
+        "address": "8351 Bartholomew Dr",
+        "city": "North Fort Myers",
+        "state": "FL",
+        "zip": "33917-1758",
+        "address_key": "33917175851",
+        "latitude": "26.72156",
+        "longitude": "-81.85911"
+    },
+    "parsed_property_address": {
+        "range": "8351",
+        "pre_directional": null,
+        "street_name": "Bartholomew",
+        "suffix": "Dr",
+        "post_directional": null,
+        "suite_name": null,
+        "suite_range": null
+    },
+    "owner": {
+        "corporate_owner": null,
+        "name": "EDWARDS JOHN V",
+        "name2": null,
+        "unparsed_name1": null,
+        "unparsed_name2": null,
+        "phone": null,
+        "phone_opt_out": null
+    },
+    "owner_address": {
+        "address": null,
+        "suite": null,
+        "city": null,
+        "state": null,
+        "zip": null,
+        "carrier_route": null,
+        "matchcode": null,
+        "mail_opt_out": null
+    },
+    "values": {
+        "calculated_total_value": "17300",
+        "calculated_land_value": null,
+        "calculated_improvement_value": null,
+        "calculated_total_value_code": null,
+        "calculated_land_value_code": null,
+        "calculated_improvement_value_code": null,
+        "assessed_total_value": "17300",
+        "assessed_land_value": null,
+        "assessed_improvement_value": null,
+        "market_total_value": null,
+        "market_land_value": null,
+        "market_improvement_value": null,
+        "appraised_total_value": null,
+        "appraised_land_value": null,
+        "appraised_improvement_value": null,
+        "tax_amount": "235.82",
+        "tax_year": null
+    },
+    "current_sale": {
+        "transaction_id": null,
+        "document_year": null,
+        "deed_category_code": null,
+        "recording_date": null,
+        "sale_date": "19920109",
+        "sale_price": "69000",
+        "sale_code": null,
+        "seller_name": null,
+        "multi_apn_code": null,
+        "multi_apn_count": null,
+        "residental_model": null
+    },
+    "current_deed": {
+        "mortgage_amount": "68900",
+        "mortgage_date": null,
+        "mortgage_loan_type_code": null,
+        "mortgage_deed_type_code": null,
+        "mortgage_term_code": null,
+        "mortgage_term": null,
+        "mortgage_due_date": null,
+        "mortgage_assumption_amount": null,
+        "lender_code": null,
+        "lender_name": null,
+        "second_mortgage_amount": null,
+        "second_mortgage_loan_type_code": null,
+        "second_mortgage_deed_type_code": null
+    },
+    "prior_sale": {
+        "transaction_id": null,
+        "document_year": null,
+        "deed_category_code": null,
+        "recording_date": null,
+        "sale_date": null,
+        "sale_price": null,
+        "sale_code": null,
+        "transaction_code": null,
+        "multi_apn_code": null,
+        "multi_apn_count": null,
+        "mortgage_amount": null,
+        "deed_type_code": null
+    },
+    "lot": {
+        "front_footage": null,
+        "depth_footage": null,
+        "acreage": "2.1491",
+        "square_footage": "93615"
+    },
+    "square_footage": {
+        "universal_building": null,
+        "building_area_code": null,
+        "building_area": null,
+        "living_space": null,
+        "ground_floor": null,
+        "gross": null,
+        "adjusted_gross": null,
+        "basement": null,
+        "garage_or_parking": null
+    },
+    "building": {
+        "year_built": null,
+        "effective_year_built": null,
+        "bed_rooms": "0",
+        "total_rooms": "0",
+        "total_baths_calculated": null,
+        "total_baths": "0.00",
+        "full_baths": null,
+        "half_baths": null,
+        "one_quarter_baths": null,
+        "three_quarter_baths": null,
+        "bath_fixtures": null,
+        "air_conditioning_code": null,
+        "basement_code": null,
+        "building_code": null,
+        "improvement_code": null,
+        "condition_code": null,
+        "construction_code": null,
+        "exterior_wall_code": null,
+        "fireplace": null,
+        "fireplaces": null,
+        "fireplace_code": null,
+        "foundation_code": null,
+        "flooring_code": null,
+        "roof_framing_code": null,
+        "garage_code": null,
+        "heating_code": null,
+        "mobile_home": null,
+        "parking_spaces": null,
+        "parking_code": null,
+        "pool": null,
+        "pool_code": null,
+        "quality_code": null,
+        "roof_cover_code": null,
+        "roof_type_code": null,
+        "stories_code": null,
+        "stories": null,
+        "building_style_code": null,
+        "units": null,
+        "electricity_code": null,
+        "fuel_code": null,
+        "sewer_code": null,
+        "water_code": null
+    }
+}
+```
+
+### Base APIs
 It is recommended to read the following config options from environment variables
 From Melissa Data documentation:
 The license string should be entered as an environment variable named

--- a/lib/melissa.rb
+++ b/lib/melissa.rb
@@ -6,6 +6,10 @@ require 'melissa/addr_obj_live'
 require 'melissa/geo_point_live'
 require 'melissa/addr_obj_mock'
 require 'melissa/geo_point_mock'
+require 'melissa/web_smart/xml'
+require 'melissa/web_smart/property_api'
+require 'melissa/web_smart/client'
+
 require 'melissa/railtie' if defined?(Rails)
 
 module Melissa

--- a/lib/melissa/web_smart/client.rb
+++ b/lib/melissa/web_smart/client.rb
@@ -1,0 +1,11 @@
+require 'melissa/web_smart/property_api'
+
+module Melissa
+  module WebSmart
+    class Client
+      def property(fips, apn)
+        Melissa::WebSmart::PropertyAPI.new.property(fips, apn)
+      end
+    end
+  end
+end

--- a/lib/melissa/web_smart/property_api.rb
+++ b/lib/melissa/web_smart/property_api.rb
@@ -1,0 +1,18 @@
+require 'melissa/web_smart/xml'
+
+require 'rest-client'
+require 'nokogiri'
+
+module Melissa
+  module WebSmart
+    class PropertyAPI
+      def property(fips, apn) 
+        resp = RestClient.get('https://property.melissadata.net/v3/REST/Service.svc/doLookup',
+                              { params: { id: ENV['MELISSA_DATA_WEB_SMART_ID'],
+                                          fips: fips,
+                                          apn: apn } })
+        PropertyXMLParser.new(Nokogiri::XML(resp)).parse
+      end
+    end
+  end
+end

--- a/lib/melissa/web_smart/xml.rb
+++ b/lib/melissa/web_smart/xml.rb
@@ -1,0 +1,72 @@
+module Melissa
+  module WebSmart
+    class XMLParser
+      attr_accessor :xml_document
+
+      def initialize(xml)
+        @xml_document = xml
+      end
+
+      def children?(xml_node)
+        xml_node.children.empty? 
+      end
+
+      def viperize_hash hash
+        hash.map { |key, value| { viperize(key.to_s) => value } }.reduce(:merge)
+      end
+
+      def viperize(string)
+        word = string.to_s.dup
+        word.gsub!(/::/, '/')
+        word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+        word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+        word.tr!("-", "_")
+        word.downcase!
+        word.to_sym
+      end
+    end
+
+    class PropertyXMLParser < XMLParser
+      def parse
+        parsed_hash = {}
+        if expected_retrieved?
+          retrieved_fields.each_with_index { |f, i| parsed_hash[f] = { data: field_details[i] } }
+          parsed_hash.keys.each { |k| parsed_hash[k] = build_subdictionary(parsed_hash[k][:data]) }
+          viperize_hash(parsed_hash)
+        end
+      end
+
+      def field_details
+        record_node.children.map { |n| n.children }
+      end
+
+      def build_subdictionary(xml_vals)
+        keys = xml_vals.map(&:name)
+        vals = xml_vals.map { |v| v.children.first.text unless children? v }
+        viperize_hash(keys.zip(vals).to_h)
+      end
+
+      def expected_fields
+        [ "RecordID", "Result", "Parcel", "PropertyAddress", "ParsedPropertyAddress",
+          "Owner", "OwnerAddress", "Values", "CurrentSale", "CurrentDeed", "PriorSale",
+          "Lot", "SquareFootage", "Building" ].sort
+      end
+
+      def expected_fields?(fields)
+        expected_fields == fields.sort
+      end
+
+      def record_node
+        xml_document.children.first.children.last # its just how they structure it..
+      end
+
+      def retrieved_fields
+        record_node.children.map { |n| n.name }
+      end
+
+      def expected_retrieved?
+        expected_fields?(retrieved_fields)
+      end
+    end
+  end
+end

--- a/melissa.gemspec
+++ b/melissa.gemspec
@@ -15,8 +15,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Melissa::VERSION
 
-  gem.add_dependency 'activesupport' # added to support underscore method.
-  gem.add_dependency 'minitest'      # added as a dependency of activesupport and for testing.
-  gem.add_dependency 'ffi'           #used for converting c libraries to ruby
-  gem.add_dependency 'thread_safe'   # added to support callbacks
+  gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'minitest'
+
+  gem.add_runtime_dependency 'activesupport'
+  gem.add_runtime_dependency 'ffi'
+  gem.add_runtime_dependency 'thread_safe'
+  gem.add_runtime_dependency 'rest-client'
+  gem.add_runtime_dependency 'nokogiri'
 end

--- a/test/smart_web_property_api_test.rb
+++ b/test/smart_web_property_api_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+require 'pry'
+
+class PropertyAPITest < MiniTest::Test
+  describe Melissa::WebSmart::Client do
+    it 'gets a response' do
+      res = Melissa::WebSmart::Client.new.property("12071", "24-43-24-03-00022.0040")
+      assert res[:result].keys.sort == [:code, :description]
+    end
+  end
+end


### PR DESCRIPTION
This includes:
- update .gitignore to ignore new secrets requirements
- add rest-client, nokogiri, and pry gems
- require new smart_web dir in main module
- build out base xml parsing class
- build out property-specific xml parsing class
- convert responses to ruby-syntax snakecase
- test the endpoint (no mock/stub - FIXME)
- build out property API class to interface with client
- document these additions to the library

I have not mocked/stubbed the test, as I have not done that in MiniTest before and this needed to be built out quickly for some client needs. We can easily maintain our own fork but I figured I would propose merging this module in since it touches/modifies nothing else and only adds documented functionality.
